### PR TITLE
Fix client type with account for signTxAuthDataLib

### DIFF
--- a/contracts-sdk/src/lib/schemas.ts
+++ b/contracts-sdk/src/lib/schemas.ts
@@ -58,9 +58,9 @@ export type Environment = "local" | "dev" | "stage" | "prod" | "branch";
 export type WalletClientExtended = Client<
   Transport,
   Chain,
-  Account | undefined,
+  Account,
   RpcSchema,
-  PublicActions & WalletActions
+  PublicActions & WalletActions<Chain, Account>
 >;
 
 // Tx Auth Data SIgnature

--- a/contracts-sdk/src/lib/signTxAuthData.ts
+++ b/contracts-sdk/src/lib/signTxAuthData.ts
@@ -37,7 +37,6 @@ export async function signTxAuthDataViem(
     throw new Error("txAuth wallet doesn't have an account");
   }
   const signature = await walletClient.signMessage({
-    account: walletClient.account?.address,
     message: { raw: messageHash },
   });
   return signature;


### PR DESCRIPTION
Changed the client type to be conform to what we have in our api: account is defined and shouldn't be used in signMessage call