### PR TITLE
dynamically set signature duration based on chainIds

### DIFF
--- a/contracts-sdk/src/lib/getSignatureValidityDuration.ts
+++ b/contracts-sdk/src/lib/getSignatureValidityDuration.ts
@@ -1,0 +1,32 @@
+const DESIRED_VALIDITY_DURATION = 5 * 60; //5 minutes
+
+const blockTimes: Record<string, number> = {
+  "1": 12, // Ethereum Mainnet
+  "5": 12, // Goerli Testnet
+  "11155111": 12, // Sepolia Testnet
+  "42161": 0.26, // Arbitrum One
+  "421613": 0.26, // Arbitrum Goerli Testnet
+  "421614": 0.26, // Arbitrum Sepolia Testnet
+  "10": 2, // Optimism
+  "420": 2, // Optimism Goerli Testnet
+  "11155420": 2, // Optimism Sepolia Testnet
+  "43114": 3, // Avalanche C-Chain Mainnet
+  "43113": 3, // Avalanche Fuji Testnet
+  "137": 2, // Polygon Mainnet
+  "80001": 2, // Polygon Mumbai Testnet
+  "8453": 2, // Base
+  "84531": 2, // Base Goerli
+  "84532": 2, // Base Sepolia
+  "1284": 12, // Moonbeam
+  "1285": 12, // Moonriver
+};
+
+export function getSignatureValidityBlockDuration(chainId: number) {
+  if (blockTimes[chainId.toString()]) {
+    return Math.floor(
+      DESIRED_VALIDITY_DURATION / blockTimes[chainId.toString()]
+    );
+  } else {
+    return 25;
+  }
+}

--- a/contracts-sdk/src/lib/signTxAuthDataEthers.ts
+++ b/contracts-sdk/src/lib/signTxAuthDataEthers.ts
@@ -1,12 +1,6 @@
 import { ethers } from "ethers";
-import {
-  Address,
-  TxAuthData,
-  TxAuthInput,
-  WalletClientExtended,
-} from "./schemas";
-
-const SIGNATURE_VALIDITY_DURATION = 50;
+import { Address, TxAuthData, TxAuthInput } from "./schemas";
+import { getSignatureValidityBlockDuration } from "./getSignatureValidityDuration";
 
 // Generating functionCallData with ethers
 export function generateFunctionCallDataEthers(
@@ -42,8 +36,8 @@ export async function signTxAuthDataEthers(
 }
 
 export const getNonceEthers = async (
-  contractAddress: string,
-  userAddress: string,
+  contractAddress: Address,
+  userAddress: Address,
   contractABI: any[],
   provider: ethers.providers.Provider
 ) => {
@@ -58,9 +52,10 @@ export const signTxAuthDataLibEthers = async (
 ) => {
   const provider = signer.provider;
   const blockNumber = await provider.getBlockNumber();
-  const blockExpiration =
-    txAuthInput.blockExpiration ?? blockNumber + SIGNATURE_VALIDITY_DURATION;
   const chainID = txAuthInput.chainID ?? (await provider.getNetwork()).chainId;
+  const blockExpiration =
+    txAuthInput.blockExpiration ??
+    blockNumber + getSignatureValidityBlockDuration(chainID);
   const nonce =
     txAuthInput.nonce ??
     (await getNonceEthers(
@@ -78,7 +73,7 @@ export const signTxAuthDataLibEthers = async (
   );
 
   // Remove the placeholder for the signature
-  const argsWithSelector = functionCallData.slice(0, -128) as `0x${string}`;
+  const argsWithSelector = functionCallData.slice(0, -128) as Address;
 
   const txAuthData = {
     functionCallData: argsWithSelector,

--- a/contracts-sdk/src/lib/signTxAuthDataViem.ts
+++ b/contracts-sdk/src/lib/signTxAuthDataViem.ts
@@ -6,8 +6,7 @@ import {
   TxAuthInput,
   WalletClientExtended,
 } from "./schemas";
-
-const SIGNATURE_VALIDITY_DURATION = 50;
+import { getSignatureValidityBlockDuration } from "./getSignatureValidityDuration";
 
 // Generating functionCallData with viem
 export function generateFunctionCallDataViem(
@@ -68,15 +67,15 @@ export const signTxAuthDataLib = async (
 ) => {
   // Build Signature
 
+  // Get chainId
+  const chainID =
+    txAuthInput.chainID ?? (await txAuthWalletClient.getChainId());
+
   // Get Block Expiration
   const blockExpiration =
     txAuthInput.blockExpiration ??
     Number((await txAuthWalletClient.getBlock({ blockTag: "latest" })).number) +
-      SIGNATURE_VALIDITY_DURATION;
-
-  // Get chainId
-  const chainID =
-    txAuthInput.chainID ?? (await txAuthWalletClient.getChainId());
+      getSignatureValidityBlockDuration(chainID);
 
   // Get Nonce (better provide the nonce for local testing)
   const nonce =
@@ -97,7 +96,7 @@ export const signTxAuthDataLib = async (
 
   // remove 64 bytes (32 bytes for the length and 32 bytes for the fake signature itself)
   // = 128 characters
-  const argsWithSelector = functionCallData.slice(0, -128) as `0x${string}`;
+  const argsWithSelector = functionCallData.slice(0, -128) as Address;
 
   const txAuthData = {
     functionCallData: argsWithSelector,


### PR DESCRIPTION
Based on chain block times:

```
const blockTimes: Record<string, number> = {
  "1": 12, // Ethereum Mainnet
  "5": 12, // Goerli Testnet
  "11155111": 12, // Sepolia Testnet
  "42161": 0.26, // Arbitrum One
  "421613": 0.26, // Arbitrum Goerli Testnet
  "421614": 0.26, // Arbitrum Sepolia Testnet
  "10": 2, // Optimism
  "420": 2, // Optimism Goerli Testnet
  "11155420": 2, // Optimism Sepolia Testnet
  "43114": 3, // Avalanche C-Chain Mainnet
  "43113": 3, // Avalanche Fuji Testnet
  "137": 2, // Polygon Mainnet
  "80001": 2, // Polygon Mumbai Testnet
  "8453": 2, // Base
  "84531": 2, // Base Goerli
  "84532": 2, // Base Sepolia
  "1284": 12, // Moonbeam
  "1285": 12, // Moonriver
};
```